### PR TITLE
Changed 'build-cjs' output dir to 'cjs' folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+.DS_Store
+npm-debug.log
+.npmrc
+node_modules
 umd
+cjs

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node ./scripts/build.js",
-    "build-cjs": "babel ./modules -d . --ignore '__tests__'",
+    "build-cjs": "babel modules -d ./cjs --ignore '__tests__'",
     "build-umd": "webpack modules/index.js umd/react-history.js",
     "build-min": "webpack -p modules/index.js umd/react-history.min.js",
     "prepublish": "node ./scripts/build.js",
@@ -15,6 +15,8 @@
     "test": "npm run lint && karma start",
     "lint": "eslint modules"
   },
+  "files": ["umd", "cjs"],
+  "main": "cjs/index.js",
   "dependencies": {
     "history": "^4.5.0",
     "prop-types": "^15.6.0"


### PR DESCRIPTION
To avoid committing files by mistake we have to add them to .gitignore. It's less difficult
when we can ignore the `umd` and `cjs` folders, instead of polluting the root dir with compiled files.

In addition, we no longer include all default files, which was making `CONTRIBUTING.md` part of the tarball downloaded by NPM on each install.

**Depends on #28**